### PR TITLE
test notifications work, but alerts fail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Sentry Telegram |travis| |codecov| |pypi|
+.Sentry Telegram |travis| |codecov| |pypi|
 =========================================
 
 Plugin for Sentry which allows sending notification via `Telegram <https://telegram.org/>`_ messenger.


### PR DESCRIPTION
I see this error in logs

```
sentry-self-hosted-worker-1 | 04:38:38 [INFO] sentry.rules: rules.fail.plugin_does_not_exist (event_id='...' plugin='sentry_telegram_py3')
```