### PR TITLE
Support latest version of sentry

### DIFF
--- a/sentry_telegram_py3/plugin.py
+++ b/sentry_telegram_py3/plugin.py
@@ -3,7 +3,11 @@ import logging
 from collections import defaultdict
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from sentry.plugins.bases import notify
 from sentry.http import safe_urlopen


### PR DESCRIPTION
Hi @vortland! 
When updating sentry self-hosted to the latest version the plugin fails, because `ugettext_lazy` was deleted in the latest Django versions. 
Sending a quick fix to support new sentry versions.
Please take a look when you have time 